### PR TITLE
Update engine.rb to fix broken plugin

### DIFF
--- a/lib/open_project/auth_cas/engine.rb
+++ b/lib/open_project/auth_cas/engine.rb
@@ -1,4 +1,6 @@
 require 'omniauth-cas'
+require 'open_project/auth_plugins'
+
 module OpenProject
   module AuthCas
     class Engine < ::Rails::Engine


### PR DESCRIPTION
This commit fixes the plugin break in 8.2. Fixed the error related to this [commit](https://github.com/opf/openproject-auth_plugins).